### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
         os:
           - ubuntu-latest
         go:
+          - "stable"
+          - "1.23"
           - "1.22"
           - "1.21"
           - "1.20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Expanded Go version testing in the CI workflow to include the latest stable version and version 1.23, improving compatibility checks and enhancing testing robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->