### PR TITLE
add reverse table for bioctal character decoding

### DIFF
--- a/bioctal.go
+++ b/bioctal.go
@@ -8,7 +8,26 @@ import (
 )
 
 // from https://www.rfc-editor.org/rfc/rfc9226.html#bioctal_seq_octaves
-const biocttable = "01234567cjzwfsbv"
+const (
+	biocttable   = "01234567cjzwfsbv"
+	reverseTable = "" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\x00\x01\x02\x03\x04\x05\x06\x07\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\x0e\x08\xff\xff\x0c\xff\xff\xff\x09\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\x0d\xff\xff\x0f\x0b\xff\xff\x0a\xff\xff\xff\xff\xff" +
+		"\xff\xff\x0e\x08\xff\xff\x0c\xff\xff\xff\x09\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\x0d\xff\xff\x0f\x0b\xff\xff\x0a\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+)
 
 // EncodedLen returns the length of an encoding of n source bytes.
 // Specifically, it returns n * 2.
@@ -54,12 +73,12 @@ func DecodedLen(x int) int { return x / 2 }
 func Decode(dst, src []byte) (int, error) {
 	i, j := 0, 1
 	for ; j < len(src); j += 2 {
-		a, ok := fromBioctalChar(src[j-1])
-		if !ok {
+		a := reverseTable[src[j-1]]
+		b := reverseTable[src[j]]
+		if a > 0x0f {
 			return i, InvalidByteError(src[j-1])
 		}
-		b, ok := fromBioctalChar(src[j])
-		if !ok {
+		if b > 0x0f {
 			return i, InvalidByteError(src[j])
 		}
 		dst[i] = (a << 4) | b
@@ -68,38 +87,12 @@ func Decode(dst, src []byte) (int, error) {
 	if len(src)%2 == 1 {
 		// Check for invalid char before reporting bad length,
 		// since the invalid char (if present) is an earlier problem.
-		if _, ok := fromBioctalChar(src[j-1]); !ok {
+		if reverseTable[src[j-1]] > 0x0f {
 			return i, InvalidByteError(src[j-1])
 		}
 		return i, ErrLength
 	}
 	return i, nil
-}
-
-func fromBioctalChar(c byte) (byte, bool) {
-	// from https://www.rfc-editor.org/rfc/rfc9226.html#bioctal_seq_octaves
-	switch c {
-	case '0', '1', '2', '3', '4', '5', '6', '7':
-		return c - '0', true
-	case 'c', 'C':
-		return 8, true
-	case 'j', 'J':
-		return 9, true
-	case 'z', 'Z':
-		return 10, true
-	case 'w', 'W':
-		return 11, true
-	case 'f', 'F':
-		return 12, true
-	case 's', 'S':
-		return 13, true
-	case 'b', 'B':
-		return 14, true
-	case 'v', 'V':
-		return 15, true
-	}
-
-	return 0, false
 }
 
 // EncodeToString returns the bioctal encoding of src.
@@ -174,7 +167,7 @@ func (d *decoder) Read(p []byte) (n int, err error) {
 		numRead, d.err = d.r.Read(d.arr[numCopy:])
 		d.in = d.arr[:numCopy+numRead]
 		if d.err == io.EOF && len(d.in)%2 != 0 {
-			if _, ok := fromBioctalChar(d.in[len(d.in)-1]); !ok {
+			if reverseTable[d.in[len(d.in)-1]] > 0x0f {
 				d.err = InvalidByteError(d.in[len(d.in)-1])
 			} else {
 				d.err = io.ErrUnexpectedEOF


### PR DESCRIPTION
```plain
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/go-bioctal
cpu: Apple M1 Pro
                │   .old.txt   │              .new.txt               │
                │    sec/op    │   sec/op     vs base                │
Decode/256-10      451.4n ± 1%   127.2n ± 1%  -71.81% (p=0.000 n=10)
Decode/1024-10    1779.5n ± 1%   487.3n ± 1%  -72.62% (p=0.000 n=10)
Decode/4096-10     7.060µ ± 0%   1.926µ ± 1%  -72.72% (p=0.000 n=10)
Decode/16384-10   28.238µ ± 1%   7.688µ ± 0%  -72.77% (p=0.000 n=10)
geomean            3.557µ        978.9n       -72.48%

                │   .old.txt   │                .new.txt                │
                │     B/s      │      B/s       vs base                 │
Decode/256-10     541.0Mi ± 1%   1918.5Mi ± 1%  +254.64% (p=0.000 n=10)
Decode/1024-10    548.8Mi ± 1%   2004.2Mi ± 1%  +265.20% (p=0.000 n=10)
Decode/4096-10    553.3Mi ± 0%   2028.2Mi ± 0%  +266.58% (p=0.000 n=10)
Decode/16384-10   553.3Mi ± 1%   2032.3Mi ± 0%  +267.27% (p=0.000 n=10)
geomean           549.1Mi         1.948Gi       +263.39%
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal decoding logic by streamlining character validation and value computation, improving code maintainability while preserving existing functionality and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->