### PR TITLE
reduce bounds checks in Decode

### DIFF
--- a/bioctal.go
+++ b/bioctal.go
@@ -71,15 +71,15 @@ func DecodedLen(x int) int { return x / 2 }
 // If the input is malformed, Decode returns the number
 // of bytes decoded before the error.
 func Decode(dst, src []byte) (int, error) {
-	i, j := 0, 1
-	for ; j < len(src); j += 2 {
-		a := reverseTable[src[j-1]]
-		b := reverseTable[src[j]]
+	i, j := 0, 0
+	for ; j < len(src)-1; j += 2 {
+		a := reverseTable[src[j]]
+		b := reverseTable[src[j+1]]
 		if a > 0x0f {
-			return i, InvalidByteError(src[j-1])
+			return i, InvalidByteError(src[j])
 		}
 		if b > 0x0f {
-			return i, InvalidByteError(src[j])
+			return i, InvalidByteError(src[j+1])
 		}
 		dst[i] = (a << 4) | b
 		i++
@@ -87,8 +87,8 @@ func Decode(dst, src []byte) (int, error) {
 	if len(src)%2 == 1 {
 		// Check for invalid char before reporting bad length,
 		// since the invalid char (if present) is an earlier problem.
-		if reverseTable[src[j-1]] > 0x0f {
-			return i, InvalidByteError(src[j-1])
+		if reverseTable[src[j]] > 0x0f {
+			return i, InvalidByteError(src[j])
 		}
 		return i, ErrLength
 	}


### PR DESCRIPTION
ref. https://zenn.dev/mattn/articles/5860d73d292f32
ref. https://github.com/golang/go/pull/78436

```plain
goarch: arm64
pkg: github.com/shogo82148/go-bioctal
cpu: Apple M1 Pro
                │  .old.txt   │              .new.txt              │
                │   sec/op    │   sec/op     vs base               │
Decode/256-10     126.8n ± 0%   117.7n ± 0%  -7.18% (p=0.000 n=10)
Decode/1024-10    495.9n ± 2%   447.4n ± 1%  -9.79% (p=0.000 n=10)
Decode/4096-10    1.961µ ± 1%   1.775µ ± 1%  -9.51% (p=0.000 n=10)
Decode/16384-10   7.812µ ± 2%   7.181µ ± 1%  -8.08% (p=0.000 n=10)
geomean           990.7n        905.0n       -8.65%

                │   .old.txt   │               .new.txt               │
                │     B/s      │     B/s       vs base                │
Decode/256-10     1.880Gi ± 0%   2.026Gi ± 0%   +7.77% (p=0.000 n=10)
Decode/1024-10    1.923Gi ± 2%   2.132Gi ± 1%  +10.84% (p=0.000 n=10)
Decode/4096-10    1.945Gi ± 1%   2.150Gi ± 1%  +10.54% (p=0.000 n=10)
Decode/16384-10   1.953Gi ± 2%   2.125Gi ± 1%   +8.80% (p=0.000 n=10)
geomean           1.925Gi        2.108Gi        +9.48%
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input parsing and error detection in the decode function to properly handle various input lengths and report errors accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->